### PR TITLE
'persistent' opt typo corrected, also checking for isWin to nix leading "/"

### DIFF
--- a/reload.js
+++ b/reload.js
@@ -1,13 +1,14 @@
 const fs = require('fs');
 const CACHE_PARAM = "?nocache=";
 const opts = {
-  persistant: true,
+  persistent: true,
   interval: 1000,
 };
 
 let stash = document.createElement("div");
 let htmlFiles = [];
 let watchedFiles = [];
+let isWin = /^win/.test(process.platform);
 
 module.exports = function() {
   _externalSheets();
@@ -20,10 +21,13 @@ function _externalSheets() {
   sheets.forEach(sheet => {
 
     let mainFile = _nodePath(sheet.href);
+	if (isWin) {
+		mainFile = mainFile.substr(1);
+	}
     let deps = sheet.getAttribute('data-sources');
     let prefix = mainFile.split('/');
 
-    prefix.splice(prefix.length - 1, 1)
+	prefix.splice(prefix.length - 1, 1);
     prefix = prefix.join('/');
 
     deps = deps ? deps.split(',') : [];


### PR DESCRIPTION
Hi, this is my first PR ever, so I'm apologizing ahead of time in case it breaks unwritten protocol (or written protocol that I haven't seen; I'm all ears in that case). In trying to implement a CSS change watch for my Electron project, I noticed that updates only happened once. I found two apparent bugs. One was a simple typo (fs.watchFile() expects a key "persistent" in the options object, and reload.js was spelling it "persistant"), and the other was a bit more complex. I'm running this in a Win32 environment because of client requirements, and _nodePath() prepends an unnecessary "/" on the file path. So the result of _nodePath("C:/big_dir/small_dir/file.css") is "/C:/big_dir/small_dir/file.css". By the time fs is setting the watch on the file, it's looking for a file at "C:/C:/big_dir/small_dir/file.css", which of course means that the reload function is never triggered. I inserted a test for "win" in the platform string, which if found, causes the script to trim off that leading character from the _nodePath output. No idea whether this will work elsewhere, so external verification is welcome.